### PR TITLE
Vote as well button for owner added

### DIFF
--- a/app/javascript/controllers/swal_controller.js
+++ b/app/javascript/controllers/swal_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     event.preventDefault()
     Swal.fire({
       title:             'Are you sure?',
-      text:              'You have selected the winner date for this event',
+      text:              'You will select the winner date for this event',
       icon:              'warning',
       showCancelButton:  true,
       confirmButtonText: 'Yes',

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,7 +23,10 @@
         <%= render "invitation_links" %>
       <%end%>
       <div class="d-flex justify-content-between align-items-end mb-2" >
-        <h2 class="text-info mt-2 mb-0">Results</strong></h2>
+        <h2 class="text-info mt-2 mb-0"><strong>Results</strong></h2>
+        <% if current_user %>
+          <a><%= link_to 'Vote as well!', new_event_date_vote_path(@event), class: "btn btn-secondary border-radius fw-bold text-white" %></a>
+        <% end %>
         <button class="d-inline-flex align-items-center btn btn-light badge"  data-bs-toggle="tooltip" data-bs-placement="top" title="<%= @event.attendees.pluck(:name).to_sentence %>">
           <span><i class="fas text-secondary fa-users"></i></span>&nbsp;<span class="badge btn-secondary total-display" data-event-subscription-target="totalDisplay"><%= @event.attendees.count %></span>
         </button>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72522628/160157553-255caaf4-e16e-4e95-a4ef-9567fe100551.png)
**The button will only be shown if you are logged in.**


**Also changed the confirmation message when an owner selects a winner date.**
From _**"You have selected the winner date for this event"**_ to:
![image](https://user-images.githubusercontent.com/72522628/160157862-5cb7e460-ad50-4b7a-9a89-c81d4e187ae7.png)
